### PR TITLE
Buildspec Gradle Configuration

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -7,12 +7,12 @@ phases:
   pre_build:
     commands:
       - echo In the pre_build phase...
-      - gradle test
+      - gradlew test
 
   build:
     commands:
       - echo Build started on `date`
-      - gradle bootJar
+      - gradlew bootJar
 
   post_build:
     commands:


### PR DESCRIPTION
# Proposed Changes
- Use `gradlew` instead of `gradle`